### PR TITLE
Remove systemd presets. Handled by systemd-presets-branding-transacti…

### DIFF
--- a/usr/lib/systemd/system-preset/50-read-only-root-fs.preset
+++ b/usr/lib/systemd/system-preset/50-read-only-root-fs.preset
@@ -1,4 +1,0 @@
-# purge-kernels does not work with read-only root filesystem
-disable purge-kernels.service
-# man cannot create cache in %post, do it at boot time
-enable man-db-create.service


### PR DESCRIPTION
…onal-server

To resolve: https://bugzilla.opensuse.org/show_bug.cgi?id=1088893

To be coordinated with https://build.opensuse.org/request/show/595331 reaching Factory and Leap 15

after this is merged, read-only-root-fs should `Require: systemd-presets-branding-transactional-server`