### PR TITLE
Add new 99volatile-overlay dracut module

### DIFF
--- a/usr/lib/dracut/modules.d/99volatile-overlay/module-setup.sh
+++ b/usr/lib/dracut/modules.d/99volatile-overlay/module-setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    return 0
+}
+
+# called by dracut
+depends() {
+    echo fs-lib
+}
+
+# called by dracut
+install() {
+    hostonly="" instmods overlay
+    inst_hook pre-pivot 50 "$moddir/mount-overlay.sh"
+}

--- a/usr/lib/dracut/modules.d/99volatile-overlay/mount-overlay.sh
+++ b/usr/lib/dracut/modules.d/99volatile-overlay/mount-overlay.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+type det_fs >/dev/null 2>&1 || . /lib/fs-lib.sh
+
+overlaydir="${NEWROOT}/tmp"
+
+mkdir -p "${overlaydir}"
+mount -t tmpfs tmpfs "${overlaydir}"
+mkdir ${overlaydir}/{etc,work-etc,var,work-var}
+
+mount -t overlay overlay "${NEWROOT}/etc -o upperdir=${overlaydir}/etc,workdir=${overlaydir}/work-etc,lowerdir=${NEWROOT}/etc
+mount -t overlay overlay "${NEWROOT}/var -o upperdir=${overlaydir}/var,workdir=${overlaydir}/work-var,lowerdir=${NEWROOT}/var


### PR DESCRIPTION
This module mounts /etc and /var as an overlay with tmpfs as upper layer.
It's unfortunately not possible to use fstab.sys for this, as workdir and
upperdir need to be created underneath the same tmpfs mountpoint.

This is intended as an alternative to the /var/lib/overlay use.