### PR TITLE
proper shell escaping in mount-overlay.sh

### DIFF
--- a/usr/lib/dracut/modules.d/99volatile-overlay/mount-overlay.sh
+++ b/usr/lib/dracut/modules.d/99volatile-overlay/mount-overlay.sh
@@ -7,7 +7,7 @@ overlaydir="${NEWROOT}/tmp"
 
 mkdir -p "${overlaydir}"
 mount -t tmpfs tmpfs "${overlaydir}"
-mkdir ${overlaydir}/{etc,work-etc,var,work-var}
+mkdir "${overlaydir}"/{etc,work-etc,var,work-var}
 
-mount -t overlay overlay "${NEWROOT}/etc -o upperdir=${overlaydir}/etc,workdir=${overlaydir}/work-etc,lowerdir=${NEWROOT}/etc
-mount -t overlay overlay "${NEWROOT}/var -o upperdir=${overlaydir}/var,workdir=${overlaydir}/work-var,lowerdir=${NEWROOT}/var
+mount -t overlay overlay "${NEWROOT}/etc" -o "upperdir=${overlaydir}/etc,workdir=${overlaydir}/work-etc,lowerdir=${NEWROOT}/etc"
+mount -t overlay overlay "${NEWROOT}/var" -o "upperdir=${overlaydir}/var,workdir=${overlaydir}/work-var,lowerdir=${NEWROOT}/var"


### PR DESCRIPTION
Signed-off-by: Olaf Hering <olaf@aepfle.de>