### PR TITLE
Fix 99volatile-overlay

### DIFF
--- a/usr/lib/dracut/modules.d/99volatile-overlay/mount-overlay.sh
+++ b/usr/lib/dracut/modules.d/99volatile-overlay/mount-overlay.sh
@@ -5,7 +5,6 @@ type det_fs >/dev/null 2>&1 || . /lib/fs-lib.sh
 
 overlaydir="${NEWROOT}/tmp"
 
-mkdir -p "${overlaydir}"
 mount -t tmpfs tmpfs "${overlaydir}"
 mkdir "${overlaydir}"/{etc,work-etc,var,work-var}
 


### PR DESCRIPTION
I didn't commit all fixes, whoops.

The missing '"' is fixed already, but the superfluous mkdir is still there.