### PR TITLE
Mount writable /boot subvolume

### DIFF
--- a/etc/grub.d/01_suse_ro_root
+++ b/etc/grub.d/01_suse_ro_root
@@ -1,0 +1,15 @@
+#!/bin/sh
+exec tail -n +3 $0
+# On read-only root file systems /boot/writable provides a writeable
+# subvolume, e.g. to store the GRUB environment block.
+set boot_rw_subvol="/boot/writable"
+btrfs-mount-subvol "(${root})" "${boot_rw_subvol}" "/@${boot_rw_subvol}"
+
+# Use above location to load and store GRUB environment variables
+if [ -f ${boot_rw_subvol}/grubenv ]; then
+  load_env -f ${boot_rw_subvol}/grubenv
+fi
+# btrfs header always beats config file
+if [ "${env_block}" ] ; then
+  load_env -f "${env_block}"
+fi


### PR DESCRIPTION
On read-only systems some components may still require write access, e.g.
to store the GRUB environment block or the Ignition firstboot flag file.
This commit will mount the corresponding shared rw area to be accessible
by further GRUB scripts, and load an eventual environment block from
there.