### PR TITLE
Add RequiresMountsFor=/etc override for systemd-udevd.service

### DIFF
--- a/usr/lib/systemd/system/systemd-udevd.service.d/etcmount.conf
+++ b/usr/lib/systemd/system/systemd-udevd.service.d/etcmount.conf
@@ -1,0 +1,3 @@
+[Unit]
+# https://github.com/systemd/systemd/issues/13947
+RequiresMountsFor=/etc


### PR DESCRIPTION
For some reason, systemd-udevd keeps /etc/udev/hwdb.bin opened, which prevents
unmounting of /etc during shutdown. It appears like having /etc as mountpoint
is not considered valid by upstream systemd, so fix this here instead.

An alternative would be to set etc.mount to LazyUnmount=true, but apparently
overlayfs doesn't keep the underlying layers pinned, which leads to
`unmount /var` returning even if there are open files in /etc. This means that
proper unmounting on shutdown would no longer be guaranteed.

See also https://github.com/systemd/systemd/issues/13947

Result:

```
[  OK  ] Stopped target Local File Systems.
         Unmounting /.snapshots...
         Unmounting /boot/grub2/i386-pc...
         Unmounting /boot/grub2/x86_64-efi...
         Unmounting /boot/writable...
         Unmounting /etc...
         Unmounting /home...
         Unmounting /opt...
         Unmounting /root...
         Unmounting /srv...
         Unmounting /tmp...
         Unmounting /usr/local...
         Stopping Flush Journal to Persistent Storage...
\x2esnapshots.mount: Succeeded.
[  OK  ] Unmounted /.snapshots.
boot-grub2-i386\x2dpc.mount: Succeeded.
[  OK  ] Unmounted /boot/grub2/i386-pc.
boot-grub2-x86_64\x2defi.mount: Succeeded.
[  OK  ] Unmounted /boot/grub2/x86_64-efi.
boot-writable.mount: Succeeded.
[  OK  ] Unmounted /boot/writable.
home.mount: Succeeded.
[  OK  ] Unmounted /home.
opt.mount: Succeeded.
[  OK  ] Unmounted /opt.
etc.mount: Succeeded.
[  OK  ] Unmounted /etc.
root.mount: Succeeded.
[  OK  ] Unmounted /root.
srv.mount: Succeeded.
[  OK  ] Unmounted /srv.
tmp.mount: Succeeded.
[  OK  ] Unmounted /tmp.
usr-local.mount: Succeeded.
[  OK  ] Unmounted /usr/local.
systemd-journal-flush.service: Succeeded.
[  OK  ] Stopped Flush Journal to Persistent Storage.
         Unmounting /var...
var.mount: Mount process exited, code=exited, status=32/n/a
[FAILED] Failed unmounting /var.
[  OK  ] Stopped target Local File Systems (Pre).
[  OK  ] Reached target Unmount All Filesystems.
systemd-remount-fs.service: Succeeded.
[  OK  ] Stopped Remount Root and Kernel File Systems.
systemd-tmpfiles-setup-dev.service: Succeeded.
[  OK  ] Stopped Create Static Device Nodes in /dev.
[  OK  ] Reached target Shutdown.
[  OK  ] Reached target Final Step.
systemd-poweroff.service: Succeeded.
[  OK  ] Started Power-Off.
[  OK  ] Reached target Power-Off.
Shutting down.
[   16.802816] reboot: Power down
```