### PR TITLE
Workaround /var being RO during systemd-journal-flush

### DIFF
--- a/usr/lib/systemd/system/systemd-journal-flush.service.d/afterlocalfs.conf
+++ b/usr/lib/systemd/system/systemd-journal-flush.service.d/afterlocalfs.conf
@@ -1,0 +1,3 @@
+[Unit]
+# https://bugzilla.opensuse.org/show_bug.cgi?id=1156421
+After=local-fs.target


### PR DESCRIPTION
/ is remounted RO during boot, which affects other subvolumes mounted at that
point as well. Those only get RW back once the next subvolume is mounted RW.

This works around boo#1156421