### PR TITLE
Better check for already existing /etc overlay

### DIFF
--- a/usr/sbin/setup-fstab-for-overlayfs
+++ b/usr/sbin/setup-fstab-for-overlayfs
@@ -6,7 +6,7 @@
 #
 
 # Already there?
-if [ -e /etc/fstab ] && grep -qE "overlay /etc" /etc/fstab; then
+if [ -e /etc/fstab ] && grep -qE '^overlay[[:space:]]+/etc[[:space:]]' /etc/fstab; then
 	exit 0 # Do nothing
 fi
 

--- a/usr/sbin/setup-fstab-for-overlayfs
+++ b/usr/sbin/setup-fstab-for-overlayfs
@@ -27,6 +27,8 @@ EOF
 
 # Workaround for bsc#1121279
 gawk -i inplace '$2 == "/var" { $4 = $4",x-initrd.mount" } { print $0 }' /etc/fstab
+
+# Make the /root subvolume available during ignition runs (boo#1161264)
 gawk -i inplace '$2 == "/root" { $4 = $4",x-initrd.mount" } { print $0 }' /etc/fstab
 
 exit 0


### PR DESCRIPTION
The call to grep assumed that it's a single space, but transactional-update
reformats the fstab so it no longer matches. If setup-fstab-for-overlayfs
was called in an already set up system with a reformatted fstab, it would run
twice and duplicate its work.

Fixes boo#1174733.