### PR TITLE
Add another workaround for read-only subvolumes (boo#1202000)

### DIFF
--- a/usr/lib/systemd/system/systemd-remount-fs.service.d/before-boot-writable.conf
+++ b/usr/lib/systemd/system/systemd-remount-fs.service.d/before-boot-writable.conf
@@ -1,0 +1,6 @@
+[Unit]
+# Make sure that at least one subvolume is mounted after the ro-remount
+# of /, so that when local-fs.target is reached, the filesystem is writable
+# again (boo#1156421). Otherwise, systemd-remount-fs.service might run after
+# subvolume mounts, leaving / read-only (boo#1202000).
+Before=boot-writable.mount


### PR DESCRIPTION
The issue that the "ro" mount option is global across a filesystem strikes
again.