### PR TITLE
Work around read-only state of subvolumes in a different way

### DIFF
--- a/usr/lib/systemd/system/systemd-remount-fs.service.d/before-boot-writable.conf
+++ b/usr/lib/systemd/system/systemd-remount-fs.service.d/before-boot-writable.conf
@@ -1,6 +1,0 @@
-[Unit]
-# Make sure that at least one subvolume is mounted after the ro-remount
-# of /, so that when local-fs.target is reached, the filesystem is writable
-# again (boo#1156421). Otherwise, systemd-remount-fs.service might run after
-# subvolume mounts, leaving / read-only (boo#1202000).
-Before=boot-writable.mount

--- a/usr/lib/systemd/system/systemd-remount-fs.service.d/writableagain.conf
+++ b/usr/lib/systemd/system/systemd-remount-fs.service.d/writableagain.conf
@@ -1,0 +1,5 @@
+[Unit]
+# Make sure that at least one subvolume is mounted RW after the
+# ro-remount of /, so that the filesystem is writable again as
+# quickly as possible (boo#1156421).
+ExecStart=/bin/sh -e -c 'if mountpoint -q /boot/writable; then mount -o remount,rw /boot/writable; fi'


### PR DESCRIPTION
Instead of messing with ordering, explicitly remount a subvolume as close to
the RO mount as possible. Hopefully that works better.