### PR TITLE
Only remount when [/sysroot]/etc is ro

### DIFF
--- a/usr/lib/dracut/modules.d/50writable-etc/writable-etc.service
+++ b/usr/lib/dracut/modules.d/50writable-etc/writable-etc.service
@@ -25,7 +25,7 @@ RemainAfterExit=yes
 # - Remount that bind mount as read-write
 # Unfortunately systemd does not support two lines for one mount point,
 # so the remount part is done manually here.
-ExecStart=/bin/sh -e -c 'if mountpoint -q /sysroot/etc; then mount -o remount,rw /sysroot/etc; fi'
+ExecStart=/bin/sh -e -c 'if findmnt -O ro -M /sysroot/etc >/dev/null; then mount -o remount,rw /sysroot/etc; fi'
 
 [Install]
 RequiredBy=initrd-fs.target

--- a/usr/lib/systemd/system/systemd-remount-fs.service.d/writableagain.conf
+++ b/usr/lib/systemd/system/systemd-remount-fs.service.d/writableagain.conf
@@ -5,4 +5,4 @@
 ExecStart=/bin/sh -e -c 'if mountpoint -q /boot/writable; then mount -o remount,rw /boot/writable; fi'
 # Changing the read/write mode of a bind mount needs a second
 # fstab entry, but systemd doesn't support set by itself
-ExecStart=/bin/sh -e -c 'if mountpoint -q /etc; then mount -o remount,rw /etc; fi'
+ExecStart=/bin/sh -e -c 'if findmnt -O ro -M /etc >/dev/null; then mount -o remount,rw /etc; fi'


### PR DESCRIPTION
The new kernel mount API returns with an error when trying to remount an overlay file system
(https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=ceecc2d87f007f9fc34e847401282111c0c29786), so only remount when /etc is read-only (i.e. the new btrfs subvolume mechanism is used).

Fixes [bsc#1246021].