### PR TITLE
writable-etc: Install findmnt instead of mountpoint

### DIFF
--- a/usr/lib/dracut/modules.d/50writable-etc/module-setup.sh
+++ b/usr/lib/dracut/modules.d/50writable-etc/module-setup.sh
@@ -5,7 +5,7 @@ check() {
 }
 
 install() {
-    inst_multiple mountpoint
+    inst_multiple findmnt
 
     inst_simple "$moddir/writable-etc.service" "$systemdsystemunitdir/writable-etc.service"
     $SYSTEMCTL -q --root "$initdir" enable writable-etc.service


### PR DESCRIPTION
The module needs findmnt meanwhile.